### PR TITLE
Update control_top.sv

### DIFF
--- a/hdl/control_top.sv
+++ b/hdl/control_top.sv
@@ -149,7 +149,6 @@ enum {
     TREAT_BREAK,
     END,
     EXCEPT_OPCODE,
-    EXCEPT_OVERFLOW,
     WAIT_READ_EXCEPT
 } state, next_state;
 


### PR DESCRIPTION
Esse estado não existe na máquina de estados. Só existe essa declaração (que foi excluída).